### PR TITLE
Lock constructor functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.0.0]
+
+### Added
+
+- `Either::left` to construct a `Left` instance
+- `Either::right` to construct a `Right` instance
+
+### Removed
+
+- `Left` and `Right` can no longer be constructed using `new`
+
+### Changed
+
+- `::of()` and `::tryCatch()` have been marked `final` to prevent extension
+
+## [1.0.0]
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -79,6 +79,38 @@ $id = function ($x) { return $x; };
 assert(Either::of('test')->either($id, $id) == 'test');
 ```
 
+### `left :: a -> Left e a`
+
+Standard constructor for `Left` instances.
+
+```php
+<?php
+
+use PhpFp\Either\Either;
+use PhpFp\Either\Constructor\Left;
+
+$either = Either::left('test');
+
+assert($either instanceof Either);
+assert($either instanceof Left);
+```
+
+### `right :: a -> Right e a`
+
+Standard constructor for `Right` instances. Typically you should call `Either::of` instead.
+
+```php
+<?php
+
+use PhpFp\Either\Either;
+use PhpFp\Either\Constructor\Right;
+
+$either = Either::right('test');
+
+assert($either instanceof Either);
+assert($either instanceof Right);
+```
+
 ### `tryCatch :: (-> a) -> Either e a`
 
 Sometimes, you will have a piece of exception-throwing code that you wish to wrap in an `Either`, and this function can help. If an exception occurs, it will be wrapped and returned in a `Left`. Otherwise, the returned value will be wrapped in a `Right`:
@@ -96,10 +128,6 @@ $g = function () { return 'hello'; };
 assert(Either::tryCatch($f)->either($id, $id) instanceof \Exception);
 assert(Either::tryCatch($g)->either($id, $id) === 'hello');
 ```
-
-### `__construct :: a -> Either e a`
-
-Standard constructor for the `Either` instances. `PhpFp\Either\Either` has an abstract constructor, so you will need to call either `PhpFp\Either\Constructor\Left::__construct` or the `Right` equivalent.
 
 ### `ap :: Either e (a -> b) | Either e a -> Either e b`
 
@@ -139,8 +167,8 @@ $addOne = function ($x) { return $x + 1; };
 $subOne = function ($x) { return $x - 1; };
 $id = function ($x) { return $x; };
 
-assert ((new Right(2))->bimap($addOne, $subOne)->either($id, $id) === 1);
-assert ((new Left(2))->bimap($addOne, $subOne)->either($id, $id) === 3);
+assert (Either::right(2)->bimap($addOne, $subOne)->either($id, $id) === 1);
+assert (Either::left(2)->bimap($addOne, $subOne)->either($id, $id) === 3);
 ```
 
 ### `chain :: Either e a | (a -> Either f b) -> Either f b`
@@ -159,8 +187,8 @@ $f = function ($x)
 
 $id = function ($x) { return $x; };
 
-assert((new Right(8))->chain($f)->either($id, $id) === 16);
-assert((new Left(8))->chain($f)->either($id, $id) === 8);
+assert(Either::right(8)->chain($f)->either($id, $id) === 16);
+assert(Either::left(8)->chain($f)->either($id, $id) === 8);
 ```
 
 ### `map :: Either e a | (a -> b) -> Either e b`
@@ -175,8 +203,8 @@ use PhpFp\Either\Constructor\{Left, Right};
 $f = function ($x) { return $x - 5; };
 $id = function ($x) { return $x; };
 
-assert((new Right(8))->map($f)->either($id, $id) === 3);
-assert((new Left(8))->map($f)->either($id, $id) === 8);
+assert(Either::right(8)->map($f)->either($id, $id) === 3);
+assert(Either::left(8)->map($f)->either($id, $id) === 8);
 ```
 
 ### `either :: Either e a | (e -> b) -> (a -> b) -> b`
@@ -191,8 +219,8 @@ use PhpFp\Either\Constructor\{Left, Right};
 $left = function ($x) { return (int) $x; };
 $right = function ($x) { $x; };
 
-assert((new Left('7'))->either($left, $right) === 7);
-assert((new Right(2))->either($left, $right) === 2);
+assert(Either::left('7')->either($left, $right) === 7);
+assert(Either::right(2)->either($left, $right) === 2);
 ```
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
         {
             "name": "Tom",
             "email": "tomjharding@live.co.uk"
+        },
+        {
+            "name": "Woody Gilk",
+            "email": "woody.gilk@gmail.com",
+            "role": "Contributor"
         }
     ],
     "autoload": {

--- a/src/Constructor/Left.php
+++ b/src/Constructor/Left.php
@@ -7,17 +7,8 @@ use PhpFp\Either\Either;
 /**
  * An OO-looking implementation of the Left constructor.
  */
-class Left extends Either
+final class Left extends Either
 {
-    /**
-     * Construct a new Left instance with a value.
-     * @param mixed $value The value to be wrapped.
-     */
-    public function __construct($value)
-    {
-        return $this->value = $value;
-    }
-
     /**
      * Do nothing; return the same value.
      * @param Either $that The parameter to apply.
@@ -36,7 +27,7 @@ class Left extends Either
      */
     public function bimap(callable $f, callable $_) : Either
     {
-        return new self($f($this->value));
+        return Either::left($f($this->value));
     }
 
     /**

--- a/src/Constructor/Right.php
+++ b/src/Constructor/Right.php
@@ -7,17 +7,8 @@ use PhpFp\Either\Either;
 /**
  * An OO-looking implementation of the Right constructor.
  */
-class Right extends Either
+final class Right extends Either
 {
-    /**
-     * Construct a new Right instance with a value.
-     * @param mixed $value The value to be wrapped.
-     */
-    public function __construct($value)
-    {
-        return $this->value = $value;
-    }
-
     /**
      * Apply a wrapped paramater to this wrapped function.
      * @param Either $that The parameter to apply.
@@ -41,7 +32,7 @@ class Right extends Either
      */
     public function bimap(callable $_, callable $g) : Either
     {
-        return new self($g($this->value));
+        return Either::right($g($this->value));
     }
 
     /**
@@ -61,7 +52,7 @@ class Right extends Either
      */
     public function map(callable $f) : Either
     {
-        return new self($f($this->value));
+        return Either::right($f($this->value));
     }
 
     /**

--- a/src/Either.php
+++ b/src/Either.php
@@ -10,19 +10,33 @@ use PhpFp\Either\Constructor\{Left, Right};
 abstract class Either
 {
     /**
-     * The inner value of the instance.
-     * @var mixed
+     * Construct a new Left instance with a value.
+     * @param mixed $x The value to be wrapped.
+     * @return A new Left-constructed type.
      */
-    protected $value = null;
+    final public static function left($x) : Left
+    {
+        return new Left($x);
+    }
+
+    /**
+     * Construct a new Right instance with a value.
+     * @param mixed $x The value to be wrapped.
+     * @return A new Right-constructed type.
+     */
+    final public static function right($x) : Right
+    {
+        return new Right($x);
+    }
 
     /**
      * Applicative constructor for Either.
      * @param mixed $x The value to be wrapped.
      * @return A new Right-constructed type.
      */
-    public static function of($x) : Either
+    final public static function of($x) : Either
     {
-        return new Right($x);
+        return self::right($x);
     }
 
     /**
@@ -30,20 +44,14 @@ abstract class Either
      * @param callable $f The exception-throwing function.
      * @return Either Right (with success), or Left (with exception).
      */
-    public static function tryCatch(callable $f) : Either
+    final public static function tryCatch(callable $f) : Either
     {
         try {
-            return new Right($f());
+            return self::of($f());
         } catch (\Exception $e) {
-            return new Left($e);
+            return self::left($e);
         }
     }
-
-    /**
-     * Standard constructor for an Either instance.
-     * @param mixed $value The value to wrap.
-     */
-    abstract public function __construct($value);
 
     /**
      * Apply a wrapped parameter to this wrapped function.
@@ -81,4 +89,19 @@ abstract class Either
      * @return mixed The same type for each branch.
      */
     abstract public function either(callable $f, callable $g);
+
+    /**
+     * The inner value of the instance.
+     * @var mixed
+     */
+    protected $value = null;
+
+    /**
+     * Standard constructor for an Either instance.
+     * @param mixed $value The value to wrap.
+     */
+    final private function __construct($value)
+    {
+        $this->value = $value;
+    }
 }

--- a/test/ApTest.php
+++ b/test/ApTest.php
@@ -41,7 +41,7 @@ class ApTest extends \PHPUnit_Framework_TestCase
         };
 
         $a = Either::of(5);
-        $b = new Left(4);
+        $b = Either::left(4);
 
         $this->assertEquals(
             $addTwo
@@ -57,7 +57,7 @@ class ApTest extends \PHPUnit_Framework_TestCase
             'Applies to a Left.'
         );
 
-        $subOne = new Left(
+        $subOne = Either::left(
             function ($x) {
                 return $x - 1;
             }

--- a/test/BimapTest.php
+++ b/test/BimapTest.php
@@ -43,8 +43,8 @@ class BimapTest extends \PHPUnit_Framework_TestCase
             return $x;
         };
 
-        $a = new Right(2);
-        $b = new Left(2);
+        $a = Either::right(2);
+        $b = Either::left(2);
 
         $this->assertEquals(
             $a->bimap($addOne, $takeOne)

--- a/test/ChainTest.php
+++ b/test/ChainTest.php
@@ -39,7 +39,7 @@ class ChainTest extends \PHPUnit_Framework_TestCase
         };
 
         $a = Either::of(5);
-        $b = new Left(4);
+        $b = Either::left(4);
 
         $this->assertEquals(
             $a->chain($addTwo)->either($id, $id),

--- a/test/ConstructorTest.php
+++ b/test/ConstructorTest.php
@@ -36,13 +36,13 @@ class ConstructorTest extends \PHPUnit_Framework_TestCase
         };
 
         $this->assertEquals(
-            (new Right(2))->either($id, $id),
+            Either::right(2)->either($id, $id),
             2,
             'Constructs a Right.'
         );
 
         $this->assertEquals(
-            (new Left(2))->either($id, $id),
+            Either::left(2)->either($id, $id),
             2,
             'Constructs a Left.'
         );

--- a/test/EitherTest.php
+++ b/test/EitherTest.php
@@ -38,8 +38,8 @@ class EitherTest extends \PHPUnit_Framework_TestCase
             return $x - 1;
         };
 
-        $a = new Right(2);
-        $b = new Left(2);
+        $a = Either::right(2);
+        $b = Either::left(2);
 
         $this->assertEquals(
             $a->either($addOne, $takeOne),

--- a/test/MapTest.php
+++ b/test/MapTest.php
@@ -38,8 +38,8 @@ class MapTest extends \PHPUnit_Framework_TestCase
             return $x;
         };
 
-        $a = new Right(5);
-        $b = new Left(4);
+        $a = Either::right(5);
+        $b = Either::left(4);
 
         $this->assertEquals(
             $a->map($addTwo)->either($id, $id),


### PR DESCRIPTION
This removes the ability to construct new instances externally. All
construction must be done via `Either::left` or `Either::right` and this
functionality cannot be extended.

Also enforces `final` on all static methods, as their functionality
should never be changed by extension.

Refs #6 